### PR TITLE
Handle fragment base time in mp4 muxer

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/Mp4FromDashWriter.java
@@ -185,8 +185,12 @@ public class Mp4FromDashWriter {
             Mp4DashChunk chunk;
             while ((chunk = readers[i].getNextChunk(true)) != null) {
 
-                if (defaultMediaTime[i] < 1 && chunk.moof.traf.tfhd.defaultSampleDuration > 0) {
-                    defaultMediaTime[i] = chunk.moof.traf.tfhd.defaultSampleDuration;
+                if (defaultMediaTime[i] < 1) {
+                    if (chunk.moof.traf.tfdt > 0) {
+                        defaultMediaTime[i] = (int) chunk.moof.traf.tfdt;
+                    } else if (chunk.moof.traf.tfhd.defaultSampleDuration > 0) {
+                        defaultMediaTime[i] = chunk.moof.traf.tfhd.defaultSampleDuration;
+                    }
                 }
 
                 read += chunk.moof.traf.trun.chunkSize;
@@ -763,8 +767,8 @@ public class Mp4FromDashWriter {
         final int mediaTime;
 
         if (tracks[index].trak.edstElst == null) {
-            // is a audio track ¿is edst/elst optional for audio tracks?
-            mediaTime = 0x00; // ffmpeg set this value as zero, instead of defaultMediaTime
+            // there is no edit list, use the first decode timestamp as start time
+            mediaTime = defaultMediaTime;
             bMediaRate = 0x00010000;
         } else {
             mediaTime = (int) tracks[index].trak.edstElst.mediaTime;


### PR DESCRIPTION
## Summary
- respect `tfdt` base decode time when muxing fragmented MP4 streams
- ensure tracks without edit lists start at the correct timestamp

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3afa87cc8328b879685337ae5d78